### PR TITLE
Change section body text to navy blue from white.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1411,6 +1411,10 @@ hr {
 section.special, article.special {
   text-align: center; }
 
+section.wrapper {
+    color: rgba(53, 56, 73, 0.95);
+}
+
 /* Form */
 form {
   margin: 0 0 2em 0; }


### PR DESCRIPTION
The white on yellow is not great contrast wise so, for the body text, change the colour to the navy blue used elsewhere.

Before: <img width="1101" alt="Screenshot before change" src="https://cloud.githubusercontent.com/assets/394645/19004144/4bbc0230-874c-11e6-88ed-e1b8d091149e.png">
After: <img width="1288" alt="Screenshot after change" src="https://cloud.githubusercontent.com/assets/394645/19004143/4bbaf2be-874c-11e6-8444-5d2f1343401d.png">
(Ignore the poor cropping skills which makes things look larger/smaller)